### PR TITLE
feat: 게시판 CRUD 마이그레이션

### DIFF
--- a/src/main/java/com/ksuju/www/controller/BoardController.java
+++ b/src/main/java/com/ksuju/www/controller/BoardController.java
@@ -1,0 +1,511 @@
+package com.ksuju.www.controller;
+
+import com.ksuju.www.dto.*;
+import com.ksuju.www.message.MessageEnum;
+import com.ksuju.www.service.BoardService;
+import com.ksuju.www.service.CommentService;
+import com.ksuju.www.service.ZipService;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.fileupload.FileUploadException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *packageName    : com.ksuju.www.controller
+ * fileName       : BoardController
+ * author         : sungjun
+ * date           : 2024-12-12
+ * description    : 자동 주석 생성
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-12-12        kyd54       최초 생성
+ */
+
+@Controller
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final ZipService zipService;
+
+    private final BoardService boardService;
+
+    private final CommentService commentService;
+
+    // 게시글 좋아요 or 싫어요
+    @RequestMapping("/forum/notice/thumbUpDown.do")
+    @ResponseBody
+    public int thumbUpDown(@RequestParam("boardSeq") int boardSeq, @RequestParam("boardTypeSeq") int boardTypeSeq,
+                           @RequestParam("isLike") String isLike,
+                           HttpServletRequest request) {
+        System.out.println("======================= BoardController > thumbUpDown =======================");
+
+        HttpSession session = request.getSession();
+        String logInUser = (String)session.getAttribute("logInUser");
+
+        int memberSeq = -1;
+
+        try {
+            memberSeq = boardService.getMemberSeq(logInUser);
+        } catch (NullPointerException nep) {
+            System.out.println("사용자 없음");
+            // exception 던지거나 로그인 페이지로
+        }
+        BoardLikeDto boardLikeDto = new BoardLikeDto();
+
+        boardLikeDto.setBoardTypeSeq(boardTypeSeq);
+        boardLikeDto.setBoardSeq(boardSeq);
+        boardLikeDto.setMemberSeq(memberSeq);
+        boardLikeDto.setIsLike(isLike);
+
+        // 좋아요 & 싫어요 정보 없는 게시물은 새로 db에 추가해주고
+        // db에 데이터가 있으면(DuplicateKeyException) update 해준다
+        try {
+            return boardService.thumbUpDown(boardLikeDto);
+        } catch (DuplicateKeyException de) {
+            return boardService.thumbUpDownCvt(boardLikeDto);
+        }
+
+    }
+
+    // 수정페이지 파일삭제
+    @RequestMapping("/forum/notice/deleteFile.do")
+    public String deleteFile(@RequestParam HashMap<String, Object> params) {
+
+        boardService.deleteFile(params);
+
+        Integer boardSeq = Integer.parseInt((String) params.get("boardSeq"));
+        Integer boardTypeSeq = Integer.parseInt((String) params.get("boardTypeSeq"));
+        String memberId = (String) params.get("memberId");
+
+        return "redirect:/forum/notice/updatePage.do?boardSeq=" + boardSeq + "&boardTypeSeq=" + boardTypeSeq
+                + "&memberId=" + memberId;
+    }
+
+    // 모든 첨부파일 다운로드
+    @RequestMapping("/forum/notice/downloadAll.do")
+    public void downloadAll(Model model, @RequestParam Integer boardSeq, @RequestParam Integer boardTypeSeq,
+                            HttpServletResponse response) {
+
+        System.out.println("============ BoardController > downloadAll.do 진입 ============");
+
+        HashMap<String, Object> boardInfo = boardService.getReadBoard(boardSeq, boardTypeSeq);
+
+        // 파일이름 저장할 List 생성
+        List<String> fileNames = (List<String>) boardInfo.get("fileNames");
+        // 파일이 현재 저장된 경로를 저장한 List 생성
+        List<String> filePaths = (List<String>) boardInfo.get("filePaths");
+
+        try {
+            zipService.createZip(fileNames, filePaths);
+            zipService.downloadZip(response);
+            zipService.deleteZip();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // 첨부파일 개별 다운로드
+    @RequestMapping("/forum/notice/download.do")
+    public String download(@RequestParam int attachSeq, Model model) {
+        BoardAttachDto dto = boardService.getDownloadFileInfo(attachSeq);
+        File file = new File(dto.getSavePath());
+
+        Map<String, Object> fileInfo = new HashMap<>();
+        fileInfo.put("downloadFile", file);
+        fileInfo.put("orgFileNm", dto.getOrgFileNm());
+        model.addAttribute("fileInfo", fileInfo);
+
+        return "fileDownloadView";
+    }
+
+    // 게시글 수정
+    @RequestMapping("/forum/notice/updateBoard.do")
+    public String updateBoard(@RequestParam HashMap<String, String> params, ServletRequest request,
+                              @RequestParam(value = "attFile", required = false) MultipartFile[] attFiles,
+                              RedirectAttributes redirectAttributes) throws FileUploadException {
+
+        System.out.println("======= BoardController > updateBoard =======");
+
+        int boardTypeSeq = Integer.parseInt(params.get("boardTypeSeq"));
+        int boardSeq = Integer.parseInt(params.get("boardSeq"));
+        String memberId = params.get("memberId");
+
+        String updateResult = String.valueOf(boardService.updateBoard(params, request, attFiles));
+
+        if(updateResult.equals(MessageEnum.FAILD_BOARD_SIZE.getCode())) {
+            redirectAttributes.addFlashAttribute("errorMsg", MessageEnum.FAILD_BOARD_SIZE.getDescription());
+            redirectAttributes.addAttribute("boardTypeSeq", boardTypeSeq);
+            redirectAttributes.addAttribute("boardSeq", boardSeq);
+            redirectAttributes.addAttribute("memberId", memberId);
+            // updatePage로 리다이렉트
+            return "redirect:/forum/notice/updatePage.do";
+        }
+
+        // 수정 성공했을 때
+        return "redirect:/forum/notice/listPage.do?bdTypeSeq=" + boardTypeSeq;
+    }
+
+    // 게시글 수정 thymeleaf 이동
+    @RequestMapping("/forum/notice/updatePage.do")
+    public ModelAndView updatePage(@RequestParam HashMap<String, String> params) {
+        ModelAndView mv = new ModelAndView();
+        mv.addObject("key", Calendar.getInstance().getTimeInMillis());
+        mv.setViewName("board/update");
+
+        System.out.println("======= BoardController > updatePage =======");
+
+        int boardSeq = Integer.parseInt((String)params.get("boardSeq"));
+        int boardTypeSeq = Integer.parseInt((String)params.get("boardTypeSeq"));
+        String memberId = params.get("memberId");
+
+        HashMap<String, Object> getBoard = boardService.getReadBoard(boardSeq, boardTypeSeq);
+
+        List<BoardAttachDto> fileList = (List<BoardAttachDto>) getBoard.get("fileList");
+
+        String title = (String) getBoard.get("title");
+        String content = (String) getBoard.get("content");
+
+        mv.addObject("title", title);
+        mv.addObject("content", content);
+        mv.addObject("boardTypeSeq", boardTypeSeq);
+        mv.addObject("boardSeq", boardSeq);
+        mv.addObject("memberId", memberId);
+        mv.addObject("fileList", fileList);
+
+        return mv;
+    }
+
+    // 게시글 작성
+    @RequestMapping("/forum/notice/createBoard.do")
+    public String createBoard(@RequestParam HashMap<String, Object> params, ServletRequest request,
+                              @RequestParam(value = "attFile", required = false) MultipartFile[] attFiles,
+                              RedirectAttributes redirectAttributes) throws FileUploadException {
+
+        System.out.println("======= BoardController > createBoard =======");
+
+        String boardTypeSeq = (String) params.get("boardTypeSeq");
+
+        String createResult = boardService.boardCreate(params, request, attFiles);
+
+        if (createResult.equals(MessageEnum.FAILD_BOARD.getCode())) {
+            redirectAttributes.addFlashAttribute("errorMsg", MessageEnum.FAILD_BOARD.getDescription());
+        } else if (createResult.equals(MessageEnum.FAILD_BOARD_LOGIN.getCode())) {
+            redirectAttributes.addFlashAttribute("errorMsg", MessageEnum.FAILD_BOARD_LOGIN.getDescription());
+        } else if (createResult.equals(MessageEnum.FAILD_BOARD_SIZE.getCode())) {
+            Integer memberSeq = boardService.getMemberSeq(String.valueOf(params.get("memberId")));
+
+            // 에러 처리 로직을 Service 메서드로 위임
+            // 문자열 구분자로 title과 content 전달받음, map을 활용하는게 더 나은듯? 경험삼아 해봄
+            String[] titleAndContent = boardService.fileUploadSizeError(memberSeq, Integer.parseInt(boardTypeSeq), String.valueOf(params.get("memberId"))).split("\\|");
+            String title = titleAndContent[0];
+            String content = titleAndContent[1];
+
+            redirectAttributes.addFlashAttribute("errorMsg", MessageEnum.FAILD_BOARD_SIZE.getDescription());
+            redirectAttributes.addAttribute("title", title);
+            redirectAttributes.addAttribute("content", content);
+
+            return "redirect:/forum/notice/writePage.do?boardTypeSeq=" + boardTypeSeq;
+        }
+        return "redirect:/forum/notice/listPage.do?bdTypeSeq=" + boardTypeSeq;
+    }
+
+    // 게시글 삭제 > 댓글이 있을 경우 댓글도 다 같이 삭제해줘야 함 commentService에서 처리할 것
+    @RequestMapping("/forum/notice/deleteBoard.do")
+    public String deleteBoard(@RequestParam String memberId, @RequestParam int boardTypeSeq,
+                              @RequestParam int boardSeq) {
+
+        boardService.boardDelete(memberId, boardTypeSeq, boardSeq);
+
+        return "redirect:/forum/notice/listPage.do?bdTypeSeq=" + boardTypeSeq;
+    }
+
+    // 게시글 list 불러오기
+    @RequestMapping("/forum/notice/listPage.do")
+    public ModelAndView listPage(@RequestParam HashMap<String, String> params, HttpServletRequest request) {
+        System.out.println("======= BoardController > listPage =======");
+
+        ModelAndView mv = new ModelAndView();
+        mv.addObject("key", Calendar.getInstance().getTimeInMillis());
+
+        setDefaultParams(params);
+        mv.addObject("bdTypeSeq", params.get("bdTypeSeq"));
+
+        int page = Integer.parseInt(params.get("page"));
+        int size = Integer.parseInt(params.get("size"));
+        int start = (page - 1) * size;
+        int totalCnt = boardService.totalCnt(Integer.parseInt(params.get("bdTypeSeq")));
+
+        setPagingAttributes(mv, page, totalCnt, size);
+
+        String loginMember = getLoginMember(request);
+        Integer loginMemberSeq = getMemberSeq(loginMember);
+
+        // 아이디 인증여부 확인
+        String authYN = boardService.getAuthYN(loginMember);
+
+        if("N".equals(authYN)) {
+            params.put("logInUser", loginMember);
+            boardService.updateAuthNum(params);
+            String getEmail = boardService.getEmail(loginMember);
+            mv.setViewName("auth/authNum");
+            mv.addObject("alert", "이메일 인증이 필요합니다 가입 시 입력하신 이메일을 확인해주세요.");
+            mv.addObject("idAuth", "idAuth");
+            mv.addObject("email", getEmail);
+            return mv;
+        } else if ("guest".equals(authYN)) {
+            mv.setViewName("auth/login");
+            mv.addObject("alert", "로그인이 필요합니다.");
+            return mv;
+        }
+
+        List<BoardDto> list = getBoardList(params, start, size, loginMemberSeq);
+        mv.addObject("list", list);
+        mv.addObject("loginMember", loginMember);
+
+        // 좋아요 top 5 게시글 가져오기
+        List<Map<String, Integer>> topFive = boardService.getLikeTopFive(Integer.parseInt(params.get("bdTypeSeq")));
+
+        mv.setViewName("board/list");
+        mv.addObject("topFive", topFive);
+
+        return mv;
+    }
+
+    // 기본 페이지와 사이즈 설정
+    private void setDefaultParams(HashMap<String, String> params) {
+        if (!params.containsKey("page")) {
+            params.put("page", "1");
+        }
+        if (!params.containsKey("size")) {
+            params.put("size", "10");
+        }
+    }
+
+    // 페이징 관련
+    private void setPagingAttributes(ModelAndView mv, int page, int totalCnt, int size) {
+        PageHandler pageHandler = new PageHandler(page, totalCnt, size);
+
+        mv.addObject("startPage", pageHandler.getStartPage());
+        mv.addObject("endPage", pageHandler.getEndPage());
+        mv.addObject("currentPage", page);
+        mv.addObject("hasPrev", pageHandler.isShowPrev());
+        mv.addObject("hasNext", pageHandler.isShowNext());
+        mv.addObject("totalCnt", totalCnt);
+    }
+
+
+    // 세션에서 로그인한 회원 정보 가져옴
+    private String getLoginMember(HttpServletRequest request) {
+        HttpSession session = request.getSession();
+
+        // 비로그인 상태일때 리턴할 문자열
+        String result = "guest";
+
+        // 세션에 logInUser가 있는지 null 체크
+        String logInUser = (String) session.getAttribute("logInUser");
+
+        // 세션에 logInUser이 없으면 guest, 있으면 아이디
+        if(logInUser == null || logInUser.isEmpty()) {
+            return result;
+        } else {
+            return logInUser;
+        }
+    }
+
+
+    // 회원 번호를 가져오고 null일 경우 기본값으로 설정
+    private Integer getMemberSeq(String loginMember) {
+        Integer loginMemberSeq = boardService.getMemberSeq(loginMember);
+        if (loginMemberSeq == null) {
+            loginMemberSeq = -999999;
+        }
+        return loginMemberSeq;
+    }
+
+
+    // 게시글 목록 가져오기
+    private List<BoardDto> getBoardList(HashMap<String, String> params, int start, int size, Integer loginMemberSeq) {
+        HashMap<String, Integer> boardList = new HashMap<>();
+        boardList.put("bdTypeSeq", Integer.parseInt(params.get("bdTypeSeq")));
+        boardList.put("start", start);
+        boardList.put("size", size);
+        boardList.put("loginMemberSeq", loginMemberSeq);
+
+        return boardService.getList(boardList);
+    }
+
+
+    @RequestMapping("/forum/notice/writePage.do")
+    public ModelAndView writePage(@RequestParam HashMap<String, String> params,
+                                  ServletRequest request,
+                                  Model model) {
+
+        System.out.println("========================= writePage.do =========================");
+
+        ModelAndView mv = new ModelAndView();
+        mv.addObject("key", Calendar.getInstance().getTimeInMillis());
+
+        int boardTypeSeq = Integer.parseInt(params.get("boardTypeSeq"));
+
+        // 현재 로그인한 사용자의 id 가져오기
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpSession session = req.getSession();
+        String logInUser = (String) session.getAttribute("logInUser");
+
+        mv.setViewName("board/write");
+        mv.addObject("boardTypeSeq", boardTypeSeq);
+        mv.addObject("memberId", logInUser);
+
+        mv.addObject("title", params.get("title"));
+        mv.addObject("content", params.get("content"));
+        return mv;
+
+    }
+
+    @RequestMapping("/forum/notice/readPage.do")
+    public ModelAndView readPage(@RequestParam HashMap<String, String> params, ServletRequest request) {
+        ModelAndView mv = new ModelAndView();
+        mv.addObject("key", Calendar.getInstance().getTimeInMillis());
+        mv.setViewName("board/read");
+
+        System.out.println("========= BoardController > readPage =========");
+
+        int boardSeq = Integer.parseInt(params.get("boardSeq"));
+        int boardTypeSeq = Integer.parseInt(params.get("boardTypeSeq"));
+
+        // 클릭한 게시글 가져오기
+        HashMap<String, Object> selectBoard = boardService.getReadBoard(boardSeq, boardTypeSeq);
+
+        List<BoardAttachDto> fileList = (List<BoardAttachDto>) selectBoard.get("fileList");
+
+        // 현재 로그인한 사용자의 id 가져오기
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpSession session = req.getSession();
+
+        String logInUser = (String) session.getAttribute("logInUser");
+
+        int loginMemberSeq = boardService.getMemberSeq(logInUser);
+
+        String isLike = boardService.selectIsLike(loginMemberSeq,boardSeq,boardTypeSeq);
+
+        mv.addObject("title", selectBoard.get("title"));
+        mv.addObject("content", selectBoard.get("content"));
+        mv.addObject("memberId", selectBoard.get("memberId"));
+        mv.addObject("regDtm", selectBoard.get("reg_dtm"));
+        mv.addObject("comments", selectBoard.get("comments"));
+        mv.addObject("fileList", fileList);
+        mv.addObject("boardSeq", boardSeq);
+        mv.addObject("boardTypeSeq", boardTypeSeq);
+        mv.addObject("logInUser", logInUser);
+        mv.addObject("isLike", isLike);
+        mv.addObject("cmtIsLike", commentService.commentIsLike(loginMemberSeq,boardSeq,boardTypeSeq));
+
+        return mv;
+    }
+
+    @RequestMapping("/contact.do")
+    public ModelAndView contactView() {
+        ModelAndView mv = new ModelAndView();
+        mv.addObject("key", Calendar.getInstance().getTimeInMillis());
+        mv.setViewName("auth/contact");
+
+        return mv;
+    }
+
+    // 댓글 좋아요 or 싫어요
+    @RequestMapping("/forum/notice/commentIsLike.do")
+    @ResponseBody
+    public int commentIsLike(@RequestParam("boardSeq") int boardSeq,
+                             @RequestParam("boardTypeSeq") int boardTypeSeq,
+                             @RequestParam("cmtIsLike") String cmtIsLike,
+                             @RequestParam("commentSeq") int commentSeq,
+                             HttpServletRequest request) {
+        System.out.println("======================= BoardController > commentIsLike =======================");
+
+        HttpSession session = request.getSession();
+        String logInUser = (String)session.getAttribute("logInUser");
+
+        int memberSeq = -1;
+
+        try {
+            memberSeq = boardService.getMemberSeq(logInUser);
+        } catch (NullPointerException nep) {
+            System.out.println("사용자 없음");
+            // exception 던지거나 로그인 페이지로
+        }
+        CommentLikeDto commentLikeDto = new CommentLikeDto();
+
+        commentLikeDto.setBoardTypeSeq(boardTypeSeq);
+        commentLikeDto.setBoardSeq(boardSeq);
+        commentLikeDto.setMemberSeq(memberSeq);
+        commentLikeDto.setIsLike(cmtIsLike);
+        commentLikeDto.setCommentSeq(commentSeq);
+
+        // 좋아요 & 싫어요 정보 없는 댓글은 새로 db에 추가해주고
+        // db에 데이터가 있으면(DuplicateKeyException) update 해준다
+        try {
+            return commentService.commentUpDown(commentLikeDto);
+        } catch (DuplicateKeyException de) {
+            return commentService.commentUpDownCvt(commentLikeDto);
+        }
+    }
+
+
+    // 댓글삭제
+    @RequestMapping("/forum/notice/deleteComment.do")
+    public String deleteComment(@RequestParam HashMap<String, Object> params) {
+        System.out.println("======================= BoardController > deleteComment =======================");
+
+        commentService.deleteComment(params);
+
+        int boardSeq = Integer.parseInt((String) params.get("boardSeq"));
+        int boardTypeSeq = Integer.parseInt((String) params.get("boardTypeSeq"));
+        return "redirect:/forum/notice/readPage.do?boardTypeSeq=" + boardTypeSeq + "&boardSeq=" + boardSeq;
+    }
+
+    // 댓글수정
+    @RequestMapping("/forum/notice/updateComment.do")
+    public String updateComment(@RequestParam HashMap<String, Object> params) {
+        System.out.println("======================= BoardController > updateComment =======================");
+
+        commentService.updateComments(params);
+
+        int boardSeq = Integer.parseInt((String) params.get("boardSeq"));
+        int boardTypeSeq = Integer.parseInt((String) params.get("boardTypeSeq"));
+
+        return "redirect:/forum/notice/readPage.do?boardTypeSeq=" + boardTypeSeq + "&boardSeq=" + boardSeq;
+    }
+
+    // 댓글작성
+    @RequestMapping("/forum/notice/reply.do")
+    @ResponseBody
+    public int addComment(@RequestBody BoardCommentDto dto, HttpServletRequest request) {
+        System.out.println("======================= BoardController > reply.do =======================");
+
+        if (commentService.addComment(dto, request) == 1) {
+            return 1;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/com/ksuju/www/dto/PageHandler.java
+++ b/src/main/java/com/ksuju/www/dto/PageHandler.java
@@ -1,0 +1,127 @@
+package com.ksuju.www.dto;
+
+public class PageHandler {
+	final static int NAV_SIZE = 10;
+	int page; // 현재 페이지
+	int totalCnt; // 전체 게시물 개수
+	int pageSize; // 페이지 사이즈
+	int startPage; // 시작 페이지
+	int endPage; // 마지막 페이지
+	int totalPage; // 전체 페이지 수
+	boolean showPrev; // 이전 페이지
+	boolean showNext; // 다음 페이지
+	
+	
+	public PageHandler(int page, int totalCnt, int pageSize) {
+		this.page = page;
+		this.totalCnt = totalCnt;
+		this.pageSize = pageSize;
+		
+        totalPage = (int)Math.ceil(totalCnt / (double)pageSize);
+        startPage = (page - 1) / NAV_SIZE * NAV_SIZE + 1;
+        endPage = Math.min(startPage + NAV_SIZE - 1, totalPage);
+        showPrev = startPage != 1;
+        showNext = endPage != totalPage;     
+	}
+	
+	
+	// 이전, 게시판 번호 (i), 다음
+    public String toString() {
+        String str = "";
+        if (showPrev) {
+            str += "< 이전";
+        }
+        for (int i = startPage; i <= endPage; i++) {
+            System.out.println(" " + i + " ");
+        }
+        if (showNext) {
+            str += "다음 >";
+        }
+        return str;
+    }
+
+
+	public int getPage() {
+		return page;
+	}
+
+
+	public void setPage(int page) {
+		this.page = page;
+	}
+
+
+	public int getTotalCnt() {
+		return totalCnt;
+	}
+
+
+	public void setTotalCnt(int totalCnt) {
+		this.totalCnt = totalCnt;
+	}
+
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+
+	public int getStartPage() {
+		return startPage;
+	}
+
+
+	public void setStartPage(int startPage) {
+		this.startPage = startPage;
+	}
+
+
+	public int getEndPage() {
+		return endPage;
+	}
+
+
+	public void setEndPage(int endPage) {
+		this.endPage = endPage;
+	}
+
+
+	public int getTotalPage() {
+		return totalPage;
+	}
+
+
+	public void setTotalPage(int totalPage) {
+		this.totalPage = totalPage;
+	}
+
+
+	public boolean isShowPrev() {
+		return showPrev;
+	}
+
+
+	public void setShowPrev(boolean showPrev) {
+		this.showPrev = showPrev;
+	}
+
+
+	public boolean isShowNext() {
+		return showNext;
+	}
+
+
+	public void setShowNext(boolean showNext) {
+		this.showNext = showNext;
+	}
+
+
+	public static int getNavSize() {
+		return NAV_SIZE;
+	}
+}

--- a/src/main/java/com/ksuju/www/service/BoardService.java
+++ b/src/main/java/com/ksuju/www/service/BoardService.java
@@ -1,0 +1,429 @@
+package com.ksuju.www.service;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import com.ksuju.www.dto.*;
+import com.ksuju.www.message.MessageEnum;
+import com.ksuju.www.repository.*;
+import com.ksuju.www.util.EmailUtil;
+import com.ksuju.www.util.FileUtil;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.apache.commons.fileupload.FileUploadException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final CommentRepository commentRepository;
+
+    private final BoardRepository boardRepository;
+
+    private final JoinRepository joinRepository;
+
+    private final AuthRepository authRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final FileUtil fileUtil;
+
+    private final EmailUtil emailutil;
+
+    // 작성중이던 글 내용 가져오기
+    public HashMap<String, Object> getSave(int memberSeq, int boardTypeSeq) {
+        return boardRepository.getSave(memberSeq, boardTypeSeq);
+    }
+
+    // 아이디로 email 가져오기
+    public String getEmail(String memberID) {
+        return memberRepository.getEmail(memberID);
+    }
+
+    // 아이디 인증번호 생성 및 인증메일 발송
+    public int updateAuthNum(HashMap<String, String> params) {
+
+        String memberID = params.get("logInUser");
+        String dbEmail = memberRepository.getEmail(memberID);
+        params.put("email", dbEmail);
+
+        // 6자리의 인증번호 생성
+        int authNum = (int) (Math.random() * (999999 - 100000 + 1)) + 100000;
+
+        String putAuthNum = authNum+"";
+
+        params.put("authNum", putAuthNum);
+
+        System.out.println("alkdnsalkdnasd====>"+params);
+
+        int cnt = authRepository.updateAuthNum(params);
+        int emailExist = joinRepository.emailCount(params.get("email"));
+
+        if (emailExist == 0) {
+            return Integer.parseInt(MessageEnum.VALLID_EMAIL.getCode());
+        }
+
+        if (cnt == 1) {
+            // 인증 메일 발송
+            EmailDto email = new EmailDto();
+            email.setReceiver(params.get("email"));
+            email.setSubject("아이디 인증 메일입니다.");
+
+            String auth = "<p>" + params.get("authNum") + "</p>";
+
+            email.setText(auth);
+
+            emailutil.sendMail(email, true);
+            return cnt;
+        }
+        return cnt;
+    }
+
+    // 아이디 인증여부 가져오기
+    public String getAuthYN(String memberID) {
+
+        if(memberID.equals("guest")) {
+            return "guest";
+        } else {
+            return memberRepository.getAuthYN(memberID);
+        }
+    }
+
+
+    // 좋아요 수 가져오기
+    public List<Integer> like(List<BoardDto> list, HashMap<String, String> params) {
+        Integer bdTypeSeq = Integer.parseInt(params.get("bdTypeSeq"));
+        List<Integer> likes = new ArrayList<>();
+
+        for (BoardDto board : list) {
+            Integer boardSeq = board.getBoardSeq(); // BoardDto의 getter 메서드 사용
+            Integer likeCount = boardRepository.like(boardSeq, bdTypeSeq);
+            likes.add(likeCount);
+        }
+        return likes;
+    }
+
+    // 좋아요 여부 가져오기
+    public Map<Integer, String> getIsLikeMap(Integer memberSeq, List<Integer> boardSeqs, int boardTypeSeq) {
+        List<Map<String, Object>> isLikeList = boardRepository.selectIsLikeList(memberSeq, boardSeqs, boardTypeSeq);
+
+        // Map 변환
+        Map<Integer, String> isLikeMap = isLikeList.stream()
+                .collect(Collectors.toMap(
+                        map -> (Integer) map.get("boardSeq"),
+                        map -> (String) map.get("isLike")
+                ));
+
+        return isLikeMap;
+    }
+
+    // 게시글 좋아요 Y or N 셀렉트
+    public String selectIsLike(int memberSeq, int boardSeq, int boardTypeSeq) {
+        return boardRepository.selectIsLike(memberSeq, boardSeq, boardTypeSeq);
+    }
+
+    // 게시글 좋아요 Y or N
+    public int thumbUpDownCvt(BoardLikeDto boardLikeDto) {
+        return boardRepository.thumbUpDownCvt(boardLikeDto);
+    }
+
+    // 게시글 좋아요
+    public int thumbUpDown(BoardLikeDto boardLikeDto) {
+        return boardRepository.thumbUpDown(boardLikeDto);
+    }
+
+    // member_seq 가져오기
+    public Integer getMemberSeq(String memberId) {
+        return joinRepository.getMemberSeq(memberId);
+    }
+
+    // 수정페이지 파일 개별 삭제
+    public boolean deleteFile(@RequestParam HashMap<String, Object> params) {
+
+        int attachSeq = Integer.parseInt((String)params.get("attachSeq"));
+        int boardSeq = Integer.parseInt((String)params.get("boardSeq"));
+        int boardTypeSeq = Integer.parseInt((String)params.get("boardTypeSeq"));
+
+        return boardRepository.deleteFile(attachSeq, boardSeq, boardTypeSeq);
+    }
+
+    // attach_seq로 첨부파일 정보 가져오기
+    public BoardAttachDto getDownloadFileInfo(int attachSeq) {
+        return boardRepository.getAttachInfo(attachSeq);
+    }
+
+    // 게시글 수정
+    public int updateBoard(HashMap<String, String> params, ServletRequest request, MultipartFile[] attFiles) throws FileUploadException {
+
+        System.out.println("======= NoticeService > updateBoard =======");
+        File destFile = null;
+
+        int boardSeq = Integer.parseInt((String)params.get("boardSeq"));
+        int boardTypeSeq = Integer.parseInt((String)params.get("boardTypeSeq"));
+
+        String memberId = (String) params.get("memberId");
+
+        // 가져오기 끝
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Date nowDate = new Date();
+        String now = sdf.format(nowDate);
+
+        params.put("now", now);
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpSession session = req.getSession();
+
+        String logInUser = (String) session.getAttribute("logInUser");
+
+        String memberSeq = String.valueOf(joinRepository.getMemberSeq(memberId));
+
+        params.put("memberSeq", memberSeq);
+
+        if (logInUser.isEmpty()) {
+            return 0;
+        } else {
+            for (MultipartFile mf : attFiles) {
+                try {
+                    //물리적 파일 저장
+                    destFile = fileUtil.saveFile(mf);
+
+//					String unqFileNm = UUID.randomUUID().toString().replaceAll("-", "");
+                    BoardAttachDto boardAttachDto = new BoardAttachDto();
+                    boardAttachDto.setOrgFileNm(mf.getOriginalFilename());
+                    boardAttachDto.setBoardTypeSeq(boardTypeSeq);
+                    boardAttachDto.setBoardSeq(boardSeq);
+                    boardAttachDto.setChngFileNm(destFile.getName());
+                    boardAttachDto.setFileType(mf.getContentType());
+                    boardAttachDto.setFileSize(mf.getSize());
+                    boardAttachDto.setSavePath(destFile.getPath());
+
+                    if(Objects.requireNonNull(mf.getOriginalFilename()).isEmpty()) {
+                        continue;
+                    } else {
+                        boardRepository.insertBoardAttach(boardAttachDto);
+                    }
+                } catch (MaxUploadSizeExceededException e) {
+                    return Integer.parseInt(MessageEnum.FAILD_BOARD_SIZE.getCode());
+                }
+                catch (FileUploadException e) {
+                    return Integer.parseInt(MessageEnum.FAILD_BOARD.getCode());
+                } catch (NullPointerException e) {
+                    // 빈파일 있을경우에는 그냥 저장 (파일과 파일 사이에 null이 없다는 것을 가정)
+                    return boardRepository.updateBoard(params);
+                }
+            }
+            return boardRepository.updateBoard(params);
+        }
+
+    }
+
+    // 게시글 읽어오기
+    public HashMap<String, Object> getReadBoard(int boardSeq, int boardTypeSeq) {
+        System.out.println("============getReadBoard > boardInfo=================");
+        HashMap<String, Object> boardInfo = new HashMap<String, Object>();
+
+        boardInfo = selectBoard(boardSeq, boardTypeSeq);
+
+        Integer regMemberSeq = (Integer) boardInfo.get("reg_member_seq");
+
+        String memberId = memberRepository.selectMemberId(regMemberSeq).get("member_id");
+
+        // 저장된 파일 리스트 가져오기
+        List<BoardAttachDto> fileList = boardRepository.selectAllFile(boardTypeSeq, boardSeq);
+
+        // 파일이름 저장할 List 생성
+        List<String> fileNames = new ArrayList<>();
+        // 파일이 현재 저장된 경로를 저장한 List 생성
+        List<String> filePaths = new ArrayList<>();
+
+        // fileList에서 파일 이름과 경로 추출하여 리스트에 추가
+        for (BoardAttachDto attachDto : fileList) {
+            fileNames.add(attachDto.getOrgFileNm());
+            filePaths.add(attachDto.getSavePath());
+        }
+
+        // 댓글 목록 가져오기
+        List<BoardCommentDto> comments = commentRepository.selectComments(boardSeq, boardTypeSeq);
+
+        for (BoardCommentDto comment : comments) {
+            int memberSeq = comment.getMemberSeq();
+            HashMap<String, String> memberInfo = memberRepository.selectMemberId(memberSeq);
+
+            String getMemberId = memberInfo.get("member_id");
+            comment.setMemberNm(getMemberId);
+        }
+
+        boardInfo.put("comments", comments);
+
+        boardInfo.put("memberId", memberId);
+        boardInfo.put("fileList", fileList);
+        // 전체다운로드 할 때 사용할 것
+        boardInfo.put("fileNames", fileNames);
+        boardInfo.put("filePaths", filePaths);
+
+        return boardInfo;
+    }
+
+    // 게시글 하나만 가져오기
+    public HashMap<String, Object> selectBoard(int boardSeq, int boardTypeSeq) {
+        return boardRepository.selectBoard(boardSeq, boardTypeSeq);
+    }
+
+    // 게시글 작성
+    @Transactional
+    public String boardCreate(HashMap<String, Object> params, ServletRequest request, MultipartFile[] attFiles) throws FileUploadException {
+        System.out.println("=========================== service > boardCreate ===========================");
+
+        File destFile = null;
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Date nowDate = new Date();
+        String now = sdf.format(nowDate);
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpSession session = req.getSession();
+
+        String logInUser = (String) session.getAttribute("logInUser");
+
+        if (logInUser.isEmpty()) {
+            return MessageEnum.FAILD_BOARD_LOGIN.getCode();
+        } else {
+            int memberSeq = joinRepository.getMemberSeq(logInUser);
+
+            params.put("memberSeq", memberSeq);
+            params.put("now", now);
+
+            // 게시글 생성
+            boardRepository.boardCreate(params);
+
+            int boardTypeSeq = Integer.parseInt((String) params.get("boardTypeSeq"));
+            int boardSeq = (int) params.get("boardSeq");
+
+            for (MultipartFile mf : attFiles) {
+                // 물리적 파일 저장 > 생성되어있는 게시글에 추가하는 방식
+                try {
+                    destFile = fileUtil.saveFile(mf);
+
+//					String unqFileNm = UUID.randomUUID().toString().replaceAll("-", "");
+                    BoardAttachDto boardAttachDto = new BoardAttachDto();
+                    boardAttachDto.setOrgFileNm(mf.getOriginalFilename());
+                    boardAttachDto.setBoardTypeSeq(boardTypeSeq);
+                    boardAttachDto.setBoardSeq(boardSeq);
+                    boardAttachDto.setChngFileNm(destFile.getName());
+                    boardAttachDto.setFileType(mf.getContentType());
+                    boardAttachDto.setFileSize(mf.getSize());
+                    boardAttachDto.setSavePath(destFile.getPath());
+
+                    if(Objects.requireNonNull(mf.getOriginalFilename()).isEmpty()) {
+                        continue;
+                    } else {
+                        boardRepository.insertBoardAttach(boardAttachDto);
+                    }
+                } catch (MaxUploadSizeExceededException e) {
+                    //commentRepository.boardDelete(logInUser, boardTypeSeq, boardSeq); // 게시글 삭제
+                    return MessageEnum.FAILD_BOARD_SIZE.getCode();
+                } catch (FileUploadException e) {
+                    boardRepository.boardDelete(logInUser, boardTypeSeq, boardSeq); // 게시글 삭제
+                    return MessageEnum.FAILD_BOARD.getCode();
+                } catch (NullPointerException e) {
+                    return "빈파일";
+                }
+
+            }
+            return MessageEnum.SUCCESS_BOARD.getCode();
+        }
+    }
+
+    // 게시글 삭제하기
+    public void boardDelete(String memberId, int boardTypeSeq, int boardSeq) {
+        System.out.println("=========================== service > boardDelete ===========================");
+        boardRepository.deleteBoardAttach(boardTypeSeq, boardSeq); // 첨부파일 삭제
+        commentRepository.deleteAllComment(boardTypeSeq, boardSeq); // 댓글 삭제
+        boardRepository.boardDelete(memberId, boardTypeSeq, boardSeq);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 게시판 내 게시글 불러오기
+
+    public List<BoardDto> getList(HashMap<String, Integer> params) {
+        List<BoardDto> getList = boardRepository.getList(params);
+        int boardTypeSeq = params.get("bdTypeSeq");
+
+        // 모든 boardSeq 값을 추출
+        List<Integer> boardSeqs = getList.stream()
+                .map(BoardDto::getBoardSeq)
+                .collect(Collectors.toList());
+
+        if (boardSeqs.isEmpty()) {
+            return getList;
+        }
+
+        // 게시글의 파일 개수, 댓글 개수, 좋아요 개수를 한 번에 가져옴
+        List<Map<String, Object>> boardDetails = boardRepository.getBoardDetails(boardSeqs, boardTypeSeq);
+
+        // 파일 개수와 댓글 개수를 Map으로 변환
+        Map<Integer, Integer> fileCountMap = boardDetails.stream()
+                .collect(Collectors.toMap(
+                        map -> (Integer) map.get("boardSeq"),
+                        map -> ((Long) map.get("fileCount")).intValue()
+                ));
+
+        Map<Integer, Integer> commentCountMap = boardDetails.stream()
+                .collect(Collectors.toMap(
+                        map -> (Integer) map.get("boardSeq"),
+                        map -> ((Long) map.get("commentCount")).intValue()
+                ));
+
+        Map<Integer, Integer> isLikeMap = boardDetails.stream()
+                .collect(Collectors.toMap(
+                        map -> (Integer) map.get("boardSeq"),
+                        map -> ((Long) map.get("isLike")).intValue()
+                ));
+
+        // 각 BoardDto에 파일 개수와 댓글 개수, 좋아요 개수를 설정
+        for (BoardDto boardDto : getList) {
+            int boardSeq = boardDto.getBoardSeq();
+            boardDto.setFileCount(fileCountMap.getOrDefault(boardSeq, 0));
+            boardDto.setCommentCount(commentCountMap.getOrDefault(boardSeq, 0));
+            boardDto.setIsLike(isLikeMap.getOrDefault(boardSeq, 0));
+        }
+
+        return getList;
+    }
+
+    // ---------------------------------------------------------------------------------------
+
+    // 게시판 내 총 게시글 수
+    public int totalCnt(int bdTypeSeq) {
+        return boardRepository.totalCnt(bdTypeSeq);
+    }
+
+    // 게시판 내 인기글 top5 가져오기
+    public List<Map<String, Integer>> getLikeTopFive(int boardTypeSeq) {
+        return boardRepository.getLikeTopFive(boardTypeSeq);
+    }
+
+    // 파일 업로드 사이즈 에러
+    public String fileUploadSizeError(Integer memberSeq, Integer boardTypeSeq, String memberId) {
+        // getSave {board_seq, title, content}
+        HashMap<String, Object> getSave = this.getSave(memberSeq, boardTypeSeq);
+        Integer boardSeq = (Integer) getSave.get("board_seq");
+        String title = (String) getSave.get("title");
+        String content = (String) getSave.get("content");
+
+        // 게시글 삭제
+        this.boardDelete(memberId, boardTypeSeq, boardSeq);
+
+        // 필요한 정보를 반환 (예: 제목, 내용 등)
+        return title + "|" + content; // 제목과 내용을 구분자로 연결하여 반환
+    }
+}

--- a/src/main/java/com/ksuju/www/service/CommentService.java
+++ b/src/main/java/com/ksuju/www/service/CommentService.java
@@ -1,0 +1,73 @@
+package com.ksuju.www.service;
+
+import java.util.HashMap;
+import java.util.List;
+
+import com.ksuju.www.dto.BoardCommentDto;
+import com.ksuju.www.dto.CommentLikeDto;
+import com.ksuju.www.repository.CommentRepository;
+import com.ksuju.www.repository.JoinRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+	
+	private final CommentRepository commentRepository;
+	
+	private final JoinRepository joinRepository;
+	
+	
+	// 댓글 좋아요 Y or N 셀렉트
+	public List<HashMap<String, Object>> commentIsLike(int memberSeq, int boardSeq, int boardTypeSeq) {
+		return commentRepository.commentIsLike(memberSeq, boardSeq, boardTypeSeq);
+	}
+	
+	// 댓글 좋아요 Y or N
+	public int commentUpDownCvt(CommentLikeDto commentLikeDto) {
+		return commentRepository.commentUpDownCvt(commentLikeDto);
+	}
+	
+	// 댓글 좋아요
+	public int commentUpDown(CommentLikeDto commentLikeDto) {
+		return commentRepository.commentUpDown(commentLikeDto);
+	}
+	
+	// 댓글 삭제하기
+	public int deleteComment(HashMap<String,Object> params) {
+		return commentRepository.deleteComment(params);
+	}
+	
+	// 댓글 수정하기
+	public int updateComments(HashMap<String,Object> params) {
+		return commentRepository.updateComments(params);
+	}
+	
+	// 댓글 작성하기
+	public int addComment(BoardCommentDto dto,
+						  HttpServletRequest request) {
+		
+		System.out.println("======= NoticeService > addComment =======");
+		HttpSession session = request.getSession();
+		
+		String memberId = (String) session.getAttribute("logInUser");
+		
+		if(joinRepository.getMemberSeq(memberId) > 0) {
+			dto.setMemberSeq(joinRepository.getMemberSeq(memberId));
+		} else {
+			return -1;
+		}
+		
+	    // parentCommentSeq가 null이거나 0이면 null로 설정
+	    if (dto.getParentCommentSeq() == null || dto.getParentCommentSeq() == 0) {
+	        dto.setParentCommentSeq(null);
+	    }
+		commentRepository.insertComment(dto);
+		
+		return 1;
+	}
+}

--- a/src/main/java/com/ksuju/www/service/ZipService.java
+++ b/src/main/java/com/ksuju/www/service/ZipService.java
@@ -1,0 +1,117 @@
+package com.ksuju.www.service;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ZipService {
+
+    // 압축파일경로설정
+    // 날짜출력형식 지정
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+    // 지정한 형식을 바탕으로 날짜 출력
+    Date now = new Date();
+    String nowTime = sdf.format(now);
+
+    private String CHECK_PATH = "/home/ec2-user/files/" + nowTime;
+    private String SAVE_PATH = "/home/ec2-user/files/" + nowTime + "/downAll.zip";
+
+    // fileNames는 원래 파일 이름 , filePaths는 파일이 저장되어있는 경로
+    public void createZip(List<String> fileNames, List<String> filePaths) throws IOException {
+        File destZip = new File(CHECK_PATH);
+        // 경로가 없으면 생성
+        if (!destZip.exists()) {
+            destZip.mkdirs();
+        }
+
+        try (FileOutputStream fout = new FileOutputStream(SAVE_PATH);
+             ZipOutputStream zout = new ZipOutputStream(fout)) {
+
+            // 처리된 파일 이름을 추적하기 위한 Set (중복된 파일 압축하지 않기 위함)
+            Set<String> processedFiles = new HashSet<>();
+
+            for (int i = 0; i < filePaths.size(); i++) {
+                String sourceFile = filePaths.get(i);
+                String originalName = fileNames.get(i);
+
+                // 파일 이름이 이미 처리되었는지 확인
+                if (processedFiles.contains(originalName)) {
+                    continue; // **중복 파일은 건너뜀**
+                }
+
+                File file = new File(sourceFile);
+                if (file.exists()) {
+                    try (FileInputStream fin = new FileInputStream(file)) {
+                        // 압축 파일의 엔트리 이름을 원래 파일 이름으로 설정
+                        ZipEntry zipEntry = new ZipEntry(originalName);
+                        zout.putNextEntry(zipEntry);
+
+                        byte[] buffer = new byte[1024];
+                        int length;
+                        while ((length = fin.read(buffer)) > 0) {
+                            zout.write(buffer, 0, length);
+                        }
+                        zout.closeEntry();
+                    }
+                    // 이 파일 이름을 처리된 것으로 표시
+                    processedFiles.add(originalName);
+                } else {
+                    System.err.println("파일을 찾을 수 없습니다: " + sourceFile);
+                }
+            }
+        }
+    }
+
+    public void downloadZip(HttpServletResponse response) throws IOException {
+
+        //사용자가 전체다운로드 받았을때 다운받은 zip파일의 이름 설정
+        /*
+         * String downloadFileName = "downAll";
+         * response.setContentType("application/zip");
+         * response.addHeader("Content-Disposition", "attachment; filename=" +
+         * downloadFileName + ".zip");
+         */
+
+        // zip파일 다운로드
+        try (FileInputStream fis = new FileInputStream(SAVE_PATH);
+             BufferedInputStream bis = new BufferedInputStream(fis);
+             ServletOutputStream so = response.getOutputStream();
+             BufferedOutputStream bos = new BufferedOutputStream(so)) {
+
+            byte[] data = new byte[2048];
+            int input;
+            while ((input = bis.read(data)) != -1) {
+                bos.write(data, 0, input);
+                bos.flush();
+            }
+        }
+    }
+
+    public void deleteZip() {
+        File file = new File(SAVE_PATH);
+        if (file.exists()) {
+            if (file.delete()) {
+                System.out.println("downAll.zip파일이 성공적으로 삭제되었습니다.");
+            } else {
+                System.err.println("downAll.zip파일 삭제 실패.");
+            }
+        } else {
+            System.err.println("downAll.zip파일이 존재하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/ksuju/www/util/FileUtil.java
+++ b/src/main/java/com/ksuju/www/util/FileUtil.java
@@ -1,0 +1,65 @@
+package com.ksuju.www.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.UUID;
+
+import org.apache.commons.fileupload.FileUploadException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class FileUtil {
+	
+	// 업로드 용량 제한
+	private static final long MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1MB
+	
+	// 날짜출력형식 지정
+	SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+	// 지정한 형식을 바탕으로 날짜 출력
+    Date now = new Date();
+    String nowTime = sdf.format(now);
+	
+    //@Value("#conis('file.save.path'")
+	private String SAVE_PATH = "/home/ec2-user/files/"+nowTime;
+	
+	public File saveFile(MultipartFile mf) throws FileUploadException {
+		System.out.println("==================== FileUtil>saveFile 진입 ====================");
+		
+		File destFile = new File(SAVE_PATH);
+		
+	    // 파일이 저장될 디렉토리가 없으면 생성
+		if(!destFile.exists()) {
+			destFile.mkdirs();
+		}
+		
+		try {
+			// 업로드하는 파일 크기
+			long getByte = mf.getSize();
+			
+			if(getByte > MAX_FILE_SIZE_BYTES) {
+				System.out.println("파일의 크기는 1MB를 넘을 수 없습니다.");
+		        throw new MaxUploadSizeExceededException(MAX_FILE_SIZE_BYTES);
+			}
+			
+			// 업로드된 파일이 없거나 파일 업로드 칸이 비어 있는 경우 빈 파일이 저장되지 않도록 방지
+		    if(mf == null || mf.isEmpty()) {
+		        System.out.println("업로드된 파일이 없거나 비어 있습니다.");
+		        throw new NullPointerException();
+		    }
+		    
+			destFile = new File(SAVE_PATH, UUID.randomUUID().toString().replaceAll("-", ""));
+			
+			mf.transferTo(destFile);
+			
+			return destFile;
+			
+        } catch (IllegalStateException | IOException e) {
+            e.printStackTrace();
+            throw new FileUploadException("파일 업로드 중 오류가 발생했습니다.", e);
+        }
+	}
+}

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<th:block layout:fragment="content">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        .commentIcon {
+            width: 20px;
+            height: 20px;
+        }
+
+        .topFive {
+            display: flex;
+            flex-direction: column;
+            width: 44%;
+            border-right: 1px solid rgba(0, 0, 0, .1);
+        }
+
+        .topFive_title {
+            width: inherit;
+            margin-bottom: 10px;
+        }
+
+        .topFive_title img {
+            position: relative;
+            bottom: 2px;
+            margin-right: 5px;
+        }
+
+        .topFive_list img {
+            position: relative;
+            bottom: 2px;
+            margin-right: 5px;
+        }
+
+    </style>
+</head>
+<body>
+<section class="section--padding2">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <div>
+                    <section class="topFive">
+                        <div class="topFive_title">
+                            <img class="commentIcon" th:src="@{/assest/template/images/crown.png}" alt="Crown"/>인기글
+                        </div>
+                        <ul>
+                            <li th:each="item : ${topFive}" class="topFive_list">
+                                &middot;&nbsp;
+                                <a th:href="@{/forum/notice/readPage.do(boardSeq=${item.board_seq}, boardTypeSeq=${item.board_type_seq})}">
+                                    <span th:text="${item.title}"></span>
+                                </a>
+                                <a class="topFive_like">
+                                    <img class="commentIcon" th:src="@{/assest/template/images/tbupup.png}" alt="Thumbs Up"/>
+                                    <span th:text="${item.like_count}"></span>
+                                </a>
+                            </li>
+                        </ul>
+                    </section>
+
+                    <div class="modules__content">
+                        <div class="withdraw_module withdraw_history">
+                            <div class="withdraw_table_header">
+                                <h3>자유게시판</h3>
+                            </div>
+                            <div class="table-responsive">
+                                <table class="table withdraw__table">
+                                    <thead>
+                                    <tr>
+                                        <th>No</th>
+                                        <th>제목</th>
+                                        <th>Date</th>
+                                        <th>작성자</th>
+                                        <th>좋아요</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr th:each="item, status : ${list}">
+                                        <td th:text="${totalCnt - (currentPage - 1) * 10 - status.index}"></td>
+                                        <td>
+                                            <a th:href="@{/forum/notice/readPage.do(boardSeq=${item.boardSeq}, boardTypeSeq=${item.boardTypeSeq})}">
+                                                <span th:text="${item.title}"></span>
+                                            </a>
+                                            <span th:if="${item.fileCount != 0}">
+                                                <img class="commentIcon" th:src="@{/assest/template/images/fileImg.png}" alt="File"/>
+                                                <span th:text="'(' + ${item.fileCount} + ')'"></span>
+                                            </span>
+                                            <span th:if="${item.commentCount != 0}">
+                                                <img class="commentIcon" th:src="@{/assest/template/images/cmtImg.png}" alt="Comment"/>
+                                                <span th:text="'(' + ${item.commentCount} + ')'"></span>
+                                            </span>
+                                        </td>
+                                        <td th:text="${item.regDtm}"></td>
+                                        <td th:text="${item.memberId}"></td>
+                                        <td th:text="${item.isLike}"></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                                <div style="display: inline-block; margin: 0 5px; float: right; padding-right: 10px;">
+                                    <a th:href="@{/forum/notice/writePage.do(boardTypeSeq=${bdTypeSeq})}">
+                                        <button class="btn btn--round btn--bordered btn-sm btn-secondary">작성</button>
+                                    </a>
+                                </div>
+                                <div class="pagination-area" style="padding-top: 45px;">
+                                    <nav class="navigation pagination" role="navigation">
+                                        <div class="nav-links">
+                                            <a th:if="${hasPrev}" th:href="@{/forum/notice/listPage.do(bdTypeSeq=${bdTypeSeq}, page=${startPage - 10}, size=10)}" class="prev page-numbers">
+                                                <span class="lnr lnr-arrow-left"></span>
+                                            </a>
+                                            <th:block th:each="pageNum : ${#numbers.sequence(startPage, endPage)}">
+                                                <a th:if="${pageNum != currentPage}"
+                                                   th:href="@{/forum/notice/listPage.do(bdTypeSeq=${bdTypeSeq}, page=${pageNum}, size=10)}"
+                                                   th:text="${pageNum}"></a>
+                                                <span th:if="${pageNum == currentPage}" th:text="${pageNum}" class="current"></span>
+                                            </th:block>
+                                            <a th:if="${hasNext}" th:href="@{/forum/notice/listPage.do(bdTypeSeq=${bdTypeSeq}, page=${startPage + 10}, size=10)}" class="next page-numbers">
+                                                <span class="lnr lnr-arrow-right"></span>
+                                            </a>
+                                        </div>
+                                    </nav>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script th:inline="javascript">
+        function confirmDelete(memberId, boardTypeSeq, boardSeq) {
+            if (confirm("게시글을 삭제하시겠습니까?")) {
+                let url = /*[[@{/forum/notice/deleteBoard.do}]]*/ '/forum/notice/deleteBoard.do';
+                url += '?memberId=' + encodeURIComponent(memberId);
+                url += '&boardTypeSeq=' + encodeURIComponent(boardTypeSeq);
+                url += '&boardSeq=' + encodeURIComponent(boardSeq);
+                window.location.href = url;
+            }
+        }
+
+        function confirmUpdate(memberId, boardTypeSeq, boardSeq) {
+            if (confirm("게시글을 수정하시겠습니까?")) {
+                let url = /*[[@{/forum/notice/updatePage.do}]]*/ '/forum/notice/updatePage.do';
+                url += '?memberId=' + encodeURIComponent(memberId);
+                url += '&boardTypeSeq=' + encodeURIComponent(boardTypeSeq);
+                url += '&boardSeq=' + encodeURIComponent(boardSeq);
+                window.location.href = url;
+            }
+        }
+
+        window.onload = function () {
+            let errorMsg = /*[[${errorMsg}]]*/ '';
+            if (errorMsg && errorMsg.trim() !== '') {
+                alert(errorMsg);
+            } else {
+                console.log("list.html > 156, NULL")
+            }
+        }
+    </script>
+</section>
+</body>
+</th:block>
+</html>

--- a/src/main/resources/templates/board/read.html
+++ b/src/main/resources/templates/board/read.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<th:block layout:fragment="content">
+<head>
+    <meta charset="UTF-8">
+    <title>Forum Detail</title>
+    <link rel="stylesheet" th:href="@{/assest/template/css/trumbowyg.min.css}">
+    <style>
+        .panel {
+            background-color: white;
+            opacity: 0;
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.2s ease-out;
+        }
+        .panel.active {
+            max-height: 300px;
+            opacity: 1;
+        }
+        .commentButton {
+            width: 45px;
+            height: 25px;
+            line-height: 10px;
+            text-align: center;
+            font-size: 15px;
+            background-color: rgba(0, 0, 0, 0);
+            color: #007bff;
+            border-color: #007bff;
+        }
+    </style>
+</head>
+<body>
+<section class="support_threads_area section--padding2">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="forum_detail_area">
+                    <div class="cardify forum--issue">
+                        <div class="title_vote clearfix">
+                            <h3 th:text="${title}"></h3>
+                            <span th:if="${logInUser eq memberId}">
+                                <a href="javascript:void(0)"
+                                   style="border:1px solid; padding:2px 4px; border-radius:10%"
+                                   th:attr="data-member-id=${memberId}, data-board-type-seq=${boardTypeSeq}, data-board-seq=${boardSeq}"
+                                   onclick="confirmUpdate(this)">수정</a>
+                                <a href="javascript:void(0)"
+                                   style="border:1px solid; padding:2px 4px; border-radius:10%"
+                                   th:attr="data-member-id=${memberId}, data-board-type-seq=${boardTypeSeq}, data-board-seq=${boardSeq}"
+                                   onclick="confirmDelete(this)">삭제</a>
+                            </span>
+                            <div class="vote">
+                                <a href="#" id='cThumbUpAnchor'
+                                   th:onclick="'thumbUpDown(' + ${boardSeq} + ',' + ${boardTypeSeq} + ', \'Y\')'"
+                                   th:classappend="${isLike eq 'Y'} ? 'active' : ''">
+                                    <span class="lnr lnr-thumbs-up"></span>
+                                </a>
+                                <a href="#" id='cThubDownAnchor'
+                                   th:onclick="'thumbUpDown(' + ${boardSeq} + ',' + ${boardTypeSeq} + ', \'N\')'"
+                                   th:classappend="${isLike eq 'N'} ? 'active' : ''">
+                                    <span class="lnr lnr-thumbs-down"></span>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Post Content -->
+                        <div class="suppot_query_tag">
+                            <img class="poster_avatar" th:src="@{/assest/template/images/support_avat1.png}" alt="Support Avatar">
+                            <span th:text="${memberId}"></span>
+                            <span th:text="${regDtm}"></span>
+                        </div>
+                        <p style="margin-bottom: 0; margin-top: 19px;" th:text="${content}"></p>
+
+                        <!-- Attachments -->
+                        <h1 th:text="${attachSeq}"></h1>
+                        <div th:if="${fileList != null}">
+                            <div th:each="entry : ${fileList}">
+                                <div th:if="${entry != null}">
+                                    <a th:href="@{'download.do?attachSeq=' + ${entry.attachSeq}}">
+                                        fileName="<span th:text="${entry.orgFileNm}"></span>"
+                                        fileSize="<span th:text="${entry.fileSize}"></span>"
+                                    </a><br/>
+                                </div>
+                            </div>
+                            <!-- 전체 다운로드 -->
+                            <a href="#" id="downAllButton"
+                               th:if="${#lists.size(fileList) > 1}"
+                               th:href="@{'downloadAll.do?boardSeq=' + ${boardSeq} + '&boardTypeSeq=' + ${boardTypeSeq}}">전체다운로드</a>
+                        </div>
+
+                        <!-- Comments Section -->
+                        <div class="forum--replays cardify">
+                            <h4><span th:text="${#lists.size(comments)}"></span> Replies</h4>
+
+                            <!-- Comments List -->
+                            <div th:each="comment, status : ${comments}">
+                                <!-- Single Comment -->
+                                <div class="forum_single_reply">
+                                    <!-- Comment Content -->
+                                    ...
+                                </div>
+
+                                <!-- Edit Comment Form -->
+                                ...
+                            </div>
+
+                            <!-- Add Comment Form -->
+                            ...
+                        </div> <!-- End Comments Section -->
+                    </div> <!-- End Forum Issue -->
+                </div> <!-- End Forum Detail Area -->
+            </div> <!-- End Col -->
+        </div> <!-- End Row -->
+    </div> <!-- End Container -->
+</section>
+
+<script th:inline="javascript">
+    function addComment(boardSeq, boardTypeSeq) {
+        let url = /*[[@{/forum/notice/reply.do}]]*/ '/forum/notice/reply.do';
+        $.ajax({
+            type: 'POST',
+            url: url,
+            headers: {
+                "Content-Type": "application/json"
+            },
+            dataType: 'JSON',
+            data: JSON.stringify({
+                boardSeq: boardSeq,
+                boardTypeSeq: boardTypeSeq,
+                content: $('#trumbowyg-demo').trumbowyg('html')
+            }),
+            success: function(result) {
+                if (result == 1) {
+                    window.location.reload();
+                } else {
+                    alert('실패!');
+                }
+            },
+            error: function(request, status, error) {
+                console.log(error)
+            }
+        });
+    }
+
+    function thumbUpDown(boardSeq, boardTypeSeq, isLike) {
+        let url = /*[[@{/forum/notice/thumbUpDown.do}]]*/ '/forum/notice/thumbUpDown.do';
+        url += '?boardSeq=' + boardSeq;
+        url += '&boardTypeSeq=' + boardTypeSeq;
+        url += '&isLike=' + isLike;
+        $.ajax({
+            type: 'GET',
+            url: url,
+            headers: {
+                "Content-Type": "application/json"
+            },
+            dataType: 'text',
+            success: function(result) {
+                console.log(result)
+            },
+            error: function(request, status, error) {
+                console.log(error)
+            }
+        });
+    }
+
+    function commentIsLike(boardSeq, boardTypeSeq, cmtIsLike, commentSeq) {
+        let url = /*[[@{/forum/notice/commentIsLike.do}]]*/ '/forum/notice/commentIsLike.do';
+        url += '?boardSeq=' + boardSeq;
+        url += '&boardTypeSeq=' + boardTypeSeq;
+        url += '&cmtIsLike=' + cmtIsLike;
+        url += '&commentSeq=' + commentSeq;
+        $.ajax({
+            type: 'GET',
+            url: url,
+            headers: {
+                "Content-Type": "application/json"
+            },
+            dataType: 'text',
+            success: function(result) {
+                console.log(result)
+            },
+            error: function(request, status, error) {
+                console.log(error)
+            }
+        });
+    }
+
+    function confirmDelete(element) {
+        var memberId = element.getAttribute('data-member-id');
+        var boardTypeSeq = element.getAttribute('data-board-type-seq');
+        var boardSeq = element.getAttribute('data-board-seq');
+
+        if (confirm("게시글을 삭제하시겠습니까?")) {
+            let url = '/forum/notice/deleteBoard.do';
+            url += '?memberId=' + encodeURIComponent(memberId);
+            url += '&boardTypeSeq=' + encodeURIComponent(boardTypeSeq);
+            url += '&boardSeq=' + encodeURIComponent(boardSeq);
+            window.location.href = url;
+        }
+    }
+
+    function confirmUpdate(element) {
+        var memberId = element.getAttribute('data-member-id');
+        var boardTypeSeq = element.getAttribute('data-board-type-seq');
+        var boardSeq = element.getAttribute('data-board-seq');
+
+        if (confirm("게시글을 수정하시겠습니까?")) {
+            let url = '/forum/notice/updatePage.do';
+            url += '?memberId=' + encodeURIComponent(memberId);
+            url += '&boardTypeSeq=' + encodeURIComponent(boardTypeSeq);
+            url += '&boardSeq=' + encodeURIComponent(boardSeq);
+            window.location.href = url;
+        }
+    }
+
+    function editToggle(commentSeq) {
+        var panel = document.querySelector('.panel-' + commentSeq);
+        panel.classList.toggle('active');
+    }
+
+    window.onload = function() {
+        var elements = document.querySelectorAll('.cmtEditToggle');
+        elements.forEach(function(element) {
+            element.addEventListener('click', function() {
+                editToggle(this.getAttribute('data-commentSeq'));
+            });
+        });
+    };
+</script>
+</body>
+</th:block>
+</html>

--- a/src/main/resources/templates/board/update.html
+++ b/src/main/resources/templates/board/update.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<th:block layout:fragment="content">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" th:href="@{/assest/template/css/trumbowyg.min.css}">
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function() {
+            $('#trumbowyg-demo').trumbowyg({
+                lang: 'kr'
+            });
+        });
+    </script>
+</head>
+<body>
+<!--================================
+            START DASHBOARD AREA
+=================================-->
+<section class="support_threads_area section--padding2">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="question-form cardify p-4">
+                    <form th:action="@{/forum/notice/updateBoard.do}" method="post" enctype="multipart/form-data">
+                        <input type="hidden" name="boardTypeSeq" th:value="${boardTypeSeq}" />
+                        <input type="hidden" name="boardSeq" th:value="${boardSeq}" />
+                        <input type="hidden" name="memberId" th:value="${memberId}" />
+
+                        <div class="form-group">
+                            <div th:if="${not #strings.isEmpty(errorMsg)}">
+                                <h5 style="color: red;" th:text="${errorMsg}"></h5>
+                            </div>
+                            <label>제목</label>
+                            <input type="text" name="title" placeholder="Enter title here" required th:value="${title}">
+                        </div>
+
+                        <div class="form-group">
+                            <label>Description</label>
+                            <div id="trumbowyg-demo" th:text="${content}"></div>
+                        </div>
+
+                        <div class="form-group">
+                            <div th:if="${fileList != null}">
+                                <div th:each="entry : ${fileList}">
+                                    <div th:if="${not #strings.isEmpty(entry)}">
+                                        <a href='javascript:void(0)'>
+                                            fileName="<span th:text="${entry.orgFileNm}"></span>"&nbsp;&nbsp;
+                                            fileSize="<span th:text="${entry.fileSize}"></span>"
+                                        </a>
+                                        &nbsp;&nbsp;&nbsp;
+                                        <a id="deleteFile"
+                                           th:href="@{/deleteFile(attachSeq=${entry.attachSeq}, boardSeq=${boardSeq}, boardTypeSeq=${boardTypeSeq}, memberId=${memberId})}"
+                                           onclick="confirmDelete()">파일삭제</a>
+                                    </div>
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <!-- 목록 길이를 저장 -->
+                            <!-- 목록길이별로 파일첨부칸 추가 -->
+                            <div th:switch="${#lists.size(fileList)}">
+                                <div th:case="0">
+                                    <!-- Add 3 file upload fields -->
+                                    <div th:each="i : ${#numbers.sequence(0, 2)}">
+                                        <div class="form-group">
+                                            <div class="attachments">
+                                                <label>Attachments</label>
+                                                <label>
+                                                    <span class="lnr lnr-paperclip"></span> Add File
+                                                    <span>or Drop Files Here</span>
+                                                    <input type="file" name ="attFile" style="display:inline-block;">
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div th:case="1">
+                                    <!-- Add 2 file upload fields -->
+                                    <div th:each="i : ${#numbers.sequence(0, 1)}">
+                                        <div class="form-group">
+                                            <div class="attachments">
+                                                <label>Attachments</label>
+                                                <label>
+                                                    <span class="lnr lnr-paperclip"></span> Add File
+                                                    <span>or Drop Files Here</span>
+                                                    <input type="file" name ="attFile" style="display:inline-block;">
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div th:case="2">
+                                    <!-- Add 1 file upload field -->
+                                    <div class="form-group">
+                                        <div class="attachments">
+                                            <label>Attachments</label>
+                                            <label>
+                                                <span class="lnr lnr-paperclip"></span> Add File
+                                                <span>or Drop Files Here</span>
+                                                <input type="file" name ="attFile" style="display:inline-block;">
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- If list length is 3, no additional fields -->
+                            </div>
+                            <!-- 목록길이별로 파일첨부칸 추가 끝-->
+                        </div>
+
+                        <!-- Submit and Cancel Buttons -->
+                        <div class="form-group">
+                            <button type="submit" class="btn btn--md btn-primary">Submit Request</button>
+                            <a th:href="@{/forum/notice/listPage.do(bdTypeSeq=${boardTypeSeq})}"
+                               class="btn btn--md btn-light">Cancel</a>
+                        </div>
+
+                    </form>
+                </div><!-- ends: .question-form -->
+            </div><!-- end .col-md-12 -->
+        </div><!-- end .row -->
+    </div><!-- end .container -->
+</section><!--================================
+            END DASHBOARD AREA
+=================================-->
+</body>
+</th:block>
+</html>

--- a/src/main/resources/templates/board/write.html
+++ b/src/main/resources/templates/board/write.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<th:block layout:fragment="content">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" th:href="@{/assest/template/css/trumbowyg.min.css}">
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function() {
+            $('#trumbowyg-demo').trumbowyg({
+                lang: 'kr'
+            });
+        });
+    </script>
+</head>
+<body>
+<!--================================
+            START DASHBOARD AREA
+    =================================-->
+<section class="support_threads_area section--padding2">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="question-form cardify p-4">
+                    <form th:action="@{/forum/notice/createBoard.do}" method="post" enctype="multipart/form-data">
+                        <input type="hidden" name="boardTypeSeq" th:value="${boardTypeSeq}" />
+                        <input type="hidden" name="memberId" th:value="${memberId}" />
+                        <div class="form-group">
+                            <div th:if="${not #strings.isEmpty(errorMsg)}">
+                                <h5 style="color: red;" th:text="${errorMsg}"></h5>
+                            </div>
+                            <label>제목</label>
+                            <input type="text" name="title" placeholder="Enter title here" required th:value="${title != null ? title : ''}">
+                        </div>
+                        <div class="form-group">
+                            <label>Description</label>
+                            <div id="trumbowyg-demo" th:text="${content != null ? content : ''}"></div>
+                        </div>
+                        <div th:each="i : ${#numbers.sequence(1, 3)}" class="form-group">
+                            <div class="attachments">
+                                <label>Attachments</label>
+                                <label>
+                                    <span class="lnr lnr-paperclip"></span> Add File
+                                    <span>or Drop Files Here</span>
+                                    <input type="file" name="attFile" style="display: inline-block;">
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <button type="submit" class="btn btn--md btn-primary">Submit Request</button>
+                            <a th:href="@{/forum/notice/listPage.do(bdTypeSeq=${boardTypeSeq})}" class="btn btn--md btn-light">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+                <!-- ends: .question-form -->
+            </div>
+            <!-- end .col-md-12 -->
+        </div>
+        <!-- end .row -->
+    </div>
+    <!-- end .container -->
+</section>
+<!--================================
+            END DASHBOARD AREA
+    =================================-->
+</body>
+</th:block>
+</html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -56,6 +56,7 @@
 <script th:src="@{/assest/template/js/vendor/slick.min.js}"></script>
 <script th:src="@{/assest/template/js/vendor/tether.min.js}"></script>
 <script th:src="@{/assest/template/js/vendor/trumbowyg.min.js}"></script>
+<script th:src="@{/assest/template/js/vendor/trumbowyg/ko.js}"></script>
 <script th:src="@{/assest/template/js/vendor/waypoints.min.js}"></script>
 <script th:src="@{/assest/template/js/dashboard.js}"></script>
 <script th:src="@{/assest/template/js/main.js}"></script>


### PR DESCRIPTION
*** 과제 ***
1. 파일저장은 아직 마이그레이션 안함,
파일 업로드, 다운로드 안되는 버그 && 파일이 첨부되어 있는 게시글 수정 안되는 버그 수정 필요

2. 댓글 기능

3. 게시글에 싫어요 수가 많을 경우 음수로 리스트에 표시되게 변경

*** 수정 완료 ***
board CRUD 마이그레이션 완료

*** 유의 사항 ***
BoardService, 221번 줄  -> NullPointerException 발생 시 게시글 수정
// 빈 파일 있을경우에는 그냥 저장 (파일 배열 인덱스 사이에 null이 없다는 것을 가정)

> 파일 1번 3번 저장 시, 배열에는 순서대로 저장되도록 수정 필요
(배열 중간에 null이 있으면 안됨 아래 에러와 같음)



*** 찾은 에러 ***
파일 : 1번 2번 3번

1번 3번 저장시 3번은 저장 안됨문제 수정필요 ***
> 2번 null을 처리하는 로직 수정 요망


>> 힌트
잘못된 파일 처리: 업로드된 파일이 유효한 파일이 아니라면, 서버에서 이를 걸러내야 합니다.
예를 들어, 파일의 크기가 0이거나 확장자가 유효하지 않으면 이를 거부하거나 무시할 수 있습니다.