### PR TITLE
fix:File Download & Upload Path 수정

### DIFF
--- a/src/main/java/com/ksuju/www/service/BoardService.java
+++ b/src/main/java/com/ksuju/www/service/BoardService.java
@@ -229,7 +229,7 @@ public class BoardService {
 
     // 게시글 읽어오기
     public HashMap<String, Object> getReadBoard(int boardSeq, int boardTypeSeq) {
-        System.out.println("============getReadBoard > boardInfo=================");
+        System.out.println("============ getReadBoard > boardInfo =================");
         HashMap<String, Object> boardInfo = new HashMap<String, Object>();
 
         boardInfo = selectBoard(boardSeq, boardTypeSeq);

--- a/src/main/java/com/ksuju/www/util/FileUtil.java
+++ b/src/main/java/com/ksuju/www/util/FileUtil.java
@@ -7,13 +7,14 @@ import java.util.Date;
 import java.util.UUID;
 
 import org.apache.commons.fileupload.FileUploadException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartFile;
 
 @Component
 public class FileUtil {
-	
+
 	// 업로드 용량 제한
 	private static final long MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1MB
 	
@@ -24,11 +25,24 @@ public class FileUtil {
     String nowTime = sdf.format(now);
 	
     //@Value("#conis('file.save.path'")
-	private String SAVE_PATH = "/home/ec2-user/files/"+nowTime;
-	
+	//private String SAVE_PATH = "/home/ec2-user/files/"+nowTime;	> 기존 파일 경로 코드
+	//private String SAVE_PATH = System.getProperty("user.home") + "/files/" + nowTime;
+	private final String SAVE_PATH;
+
+	// 생성자에서 OS에 맞는 경로를 설정
+	public FileUtil() {
+		String os = System.getProperty("os.name").toLowerCase();
+		if (os.contains("win")) {
+			// 로컬 환경 (Windows)
+			SAVE_PATH = "C:/home/ec2-user/files/" + nowTime;
+		} else {
+			// 서버 환경 (Linux)
+			SAVE_PATH = "/home/ec2-user/files/" + nowTime;
+		}
+	}
+
 	public File saveFile(MultipartFile mf) throws FileUploadException {
 		System.out.println("==================== FileUtil>saveFile 진입 ====================");
-		
 		File destFile = new File(SAVE_PATH);
 		
 	    // 파일이 저장될 디렉토리가 없으면 생성
@@ -52,7 +66,7 @@ public class FileUtil {
 		    }
 		    
 			destFile = new File(SAVE_PATH, UUID.randomUUID().toString().replaceAll("-", ""));
-			
+
 			mf.transferTo(destFile);
 			
 			return destFile;


### PR DESCRIPTION
## 수정사항
* FileUtil > OS에 따라서 로컬 경로, 서버 경로 새로 설정함

## 비고
* SpringBoot 프로젝트로 파일 저장 시,
기존에 배포한 SpringFramework 프로젝트에서 다운로드 하면 빈 파일이 다운로드 됨 (DB 저장소 같음)
* 저장 경로가 같은 것은 확인, Spring Boot 마이그레이션 완료시 기존 프로젝트 폐기 예정이므로 fix는 보류